### PR TITLE
chore: update rust from v1.71.1 to v1.84.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build backend
-FROM rust:1.77.1-slim-bullseye as rust-builder
+FROM rust:1.84.1-slim-bullseye as rust-builder
 RUN apt update && apt install -y make clang pkg-config protobuf-compiler
 
 WORKDIR /rust-app

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # build backend
-FROM rust:1.77.1-slim-bullseye as rust-builder
+FROM rust:1.84.1-slim-bullseye as rust-builder
 RUN apt update && apt install -y musl-tools musl-dev make clang pkg-config protobuf-compiler
 RUN update-ca-certificates
 RUN rustup target add x86_64-unknown-linux-musl

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.1"
+channel = "1.84.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Previous updates introduced an error while building
```
Caused by:
  lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?
```

